### PR TITLE
doctrine driver: fix syntax error in pop message query

### DIFF
--- a/src/Bernard/Driver/DoctrineDriver.php
+++ b/src/Bernard/Driver/DoctrineDriver.php
@@ -103,7 +103,7 @@ class DoctrineDriver implements \Bernard\Driver
     {
         $query = 'SELECT id, message FROM bernard_messages
                   WHERE queue = :queue AND visible = :visible
-                  ORDER BY sentAt, id LIMIT 1' . $this->connection->getDatabasePlatform()->getForUpdateSql();
+                  ORDER BY sentAt, id LIMIT 1 ' . $this->connection->getDatabasePlatform()->getForUpdateSql();
 
         list($id, $message) = $this->connection->fetchArray($query, array(
             'queue' => $queueName,


### PR DESCRIPTION
This change fixes a regression which results in a syntax error in the
SQL query used by doPopMessage().
